### PR TITLE
With the updated toml-edit crate must not escape

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,7 +182,7 @@ dependencies = [
 
 [[package]]
 name = "diener"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "cargo_metadata",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diener"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Bastian Köcher <git@kchr.de>"]
 edition = "2021"
 categories = [ "command-line-utilities" ]

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -46,11 +46,11 @@ impl PointTo {
 
 impl PatchTarget {
     /// Returns the patch target in a toml compatible format.
-    fn as_string(&self) -> String {
+    fn as_str(&self) -> &str {
         match self {
-            Self::Crates => "crates-io".into(),
-            Self::Git(url) => format!("\"{}\"", url),
-            Self::Custom(custom) => format!("\"{}\"", custom),
+            Self::Crates => "crates-io",
+            Self::Git(url) => url,
+            Self::Custom(custom) => custom,
         }
     }
 }
@@ -258,7 +258,7 @@ fn add_patches_for_packages(
     patch_table.set_implicit(true);
 
     let patch_target_table = patch_table
-        .entry(&patch_target.as_string())
+        .entry(patch_target.as_str())
         .or_insert(Item::Table(Default::default()))
         .as_table_mut()
         .ok_or_else(|| anyhow!("Patch target table isn't a toml table!"))?;

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -298,6 +298,6 @@ fn add_patches_for_packages(
         Ok::<_, Error>(())
     })?;
 
-    fs::write(&cargo_toml, doc.to_string())
+    fs::write(cargo_toml, doc.to_string())
         .with_context(|| anyhow!("Failed to write manifest to {}", cargo_toml.display()))
 }

--- a/src/workspacify.rs
+++ b/src/workspacify.rs
@@ -141,7 +141,7 @@ fn rewrite_manifest(path: &Path, packages: &HashMap<String, PathBuf>) -> Result<
         .filter_map(|dep| dep.1.as_inline_table_mut().map(|v| (dep.0, v)))
         .try_for_each(|dep| handle_dep((dep.0, dep.1, path), packages))?;
 
-    fs::write(&path, toml.to_string())
+    fs::write(path, toml.to_string())
         .with_context(|| anyhow!("Failed to write manifest to {}", path.display()))
 }
 


### PR DESCRIPTION
At the moment with the updated toml-edit crate ( PR #27 ) it's creating patches like this:

```
[patch."\"https://github.com/paritytech/substrate.git\""]
```

Unfortunately cargo takes exception to this escaping and complains it's not a valid url.

This PR removes that escaping.

(We're keen on keeping the upgraded toml-edit dep as it should allow workspace properties to be used)