### PR TITLE
Fix branch/tag/rev serialization

### DIFF
--- a/src/update.rs
+++ b/src/update.rs
@@ -167,13 +167,13 @@ fn handle_dependency(name: &str, dep: &mut InlineTable, rewrite: &Rewrite, versi
 
     match version {
         Version::Tag(tag) => {
-            *dep.get_or_insert(" tag", "") = Value::from(tag.as_str()).decorated(" ", " ");
+            *dep.get_or_insert("tag", "") = Value::from(tag.as_str()).decorated(" ", " ");
         }
         Version::Branch(branch) => {
-            *dep.get_or_insert(" branch", "") = Value::from(branch.as_str()).decorated(" ", " ");
+            *dep.get_or_insert("branch", "") = Value::from(branch.as_str()).decorated(" ", " ");
         }
         Version::Rev(rev) => {
-            *dep.get_or_insert(" rev", "") = Value::from(rev.as_str()).decorated(" ", " ");
+            *dep.get_or_insert("rev", "") = Value::from(rev.as_str()).decorated(" ", " ");
         }
     }
     log::debug!("  updated: {:?} <= {}", version, name);


### PR DESCRIPTION
The `ref`, `tag` and `branch` property are incorrectly formatted in `v0.4.5`.  

### Reproduce

```bash
cd polkadot
git checkout 22f6ad937356d13f107c4de24ceee9c3932ad2ec
diener update --substrate --rev 2a18a4644fdf0bb718124455d21beb1295610987
cat runtime/kusama/Cargo.toml
```

You will see lines like:  
```toml
pallet-nis = { git = "https://github.com/paritytech/substrate", default-features = false , " rev" = "2a18a4644fdf0bb718124455d21beb1295610987" }
```
Which is does not work because of the `" rev"`.

Fixed by removing the prefix space.