### PR TITLE
Handle workspace dependencies

### DIFF
--- a/src/patch.rs
+++ b/src/patch.rs
@@ -278,6 +278,10 @@ fn add_patches_for_packages(
 
         let path: PathBuf = p.manifest_path.into();
 
+        // Workspace dependencies cannot use .path or .git
+        // Turn the workspace dependency into a normal dependency before patching it
+        *patch.remove("workspace");
+
         match &point_to {
             PointTo::Path => {
                 *patch.get_or_insert("path", "") =

--- a/src/update.rs
+++ b/src/update.rs
@@ -165,6 +165,10 @@ fn handle_dependency(name: &str, dep: &mut InlineTable, rewrite: &Rewrite, versi
     dep.remove("branch");
     dep.remove("rev");
 
+    // Workspace dependencies cannot use .tag, .branch or .rev
+    // Turn the workspace dependency into a normal dependency before patching it
+    *dep.remove("workspace");
+
     match version {
         Version::Tag(tag) => {
             *dep.get_or_insert("tag", "") = Value::from(tag.as_str()).decorated(" ", " ");

--- a/src/workspacify.rs
+++ b/src/workspacify.rs
@@ -175,6 +175,11 @@ fn handle_dep(
     dep.1.remove("git");
     dep.1.remove("branch");
     dep.1.remove("version");
+
+    // Workspace dependencies cannot use .path
+    // Turn the workspace dependency into a normal dependency before patching it
+    dep.1.remove("workspace");
+
     dep.1
         .insert("path", Value::from(relpath.to_string_lossy().as_ref()));
     dep.1


### PR DESCRIPTION
# Problem

Per https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace

> Other than optional and features, inherited dependencies cannot use any other dependency key (such as version or default-features).

`diener` doesn't take into account `workspace` dependencies, thus it would fail to effectively patch them and leave the code in a broken state.

# Solution

Remove `.workspace` from entries before patching them.

Later on a flag `--workspace-dependencies=[patch|skip]` can be added to configure this behavior.