### PR TITLE
add support for `polkadot-sdk`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Prepare new Formula
         env:
           NAME: Diener
-          DESCRIPTION: "dependency diener is a tool for easily changing Substrate or Polkadot dependency versions"
+          DESCRIPTION: "dependency diener is a tool for easily changing Polkadot SDK dependency versions"
           SITE: https://github.com
           REPO: paritytech/diener
           SHA256: ${{env.SHA256}}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.20.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
 dependencies = [
  "gimli",
 ]
@@ -54,9 +54,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
@@ -158,9 +158,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
+checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -170,7 +170,7 @@ dependencies = [
 
 [[package]]
 name = "diener"
-version = "0.4.7"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -225,9 +225,9 @@ dependencies = [
 
 [[package]]
 name = "eyre"
-version = "0.6.8"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b6b5a29c02cdc822728b7d7b8ae1bab3e3b05d44522770ddd49722eeac7eb"
+checksum = "7cd915d99f24784cdc19fd37ef22b97e3ff0ae756c7e492e9fbfe897d61e2aec"
 dependencies = [
  "indenter",
  "once_cell",
@@ -235,18 +235,18 @@ dependencies = [
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.27.3"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "git-url-parse"
@@ -306,9 +306,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -379,27 +379,27 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "9d811f3e15f28568be3407c8e7fdb6514c1cda3cb30683f15b6a1a1dc4ea14a7"
 dependencies = [
  "adler",
 ]
 
 [[package]]
 name = "object"
-version = "0.31.1"
+version = "0.32.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "owo-colors"
@@ -415,15 +415,15 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "proc-macro-error"
@@ -578,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.4"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
@@ -738,11 +738,10 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "cfg-if",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -750,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -761,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
  "valuable",
@@ -781,9 +780,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a651bc37f915e81f087d86e62a18eec5f79550c7faff886f7090b4ea757c77"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "sharded-slab",
  "thread_local",
@@ -792,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
@@ -825,9 +824,9 @@ checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,13 +3,13 @@ name = "diener"
 version = "0.5.0"
 authors = ["Bastian Köcher <git@kchr.de>"]
 edition = "2021"
-categories = [ "command-line-utilities" ]
+categories = ["command-line-utilities"]
 documentation = "https://docs.rs/diener"
 repository = "https://github.com/bkchr/diener"
-keywords = [ "cli", "substrate", "polkadot" ]
+keywords = ["cli", "substrate", "polkadot", "polkadot-sdk"]
 license = "Apache-2.0/MIT"
 description = """
-dependency diener is a tool for easily changing [Substrate](https://github.com/paritytech/substrate), [Polkadot](https://github.com/paritytech/polkadot) or [BEEFY](https://github.com/paritytech/grandpa-bridge-gadget) dependency versions
+dependency diener is a tool for easily changing [Polkadot SDK](https://github.com/paritytech/polkadot-sdk) dependency versions
 """
 readme = "./README.md"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "diener"
-version = "0.4.7"
+version = "0.5.0"
 authors = ["Bastian Köcher <git@kchr.de>"]
 edition = "2021"
 categories = [ "command-line-utilities" ]

--- a/Formula/diener.rb
+++ b/Formula/diener.rb
@@ -1,5 +1,5 @@
 class Diener < Formula
-  desc "dependency diener is a tool for easily changing Substrate or Polkadot dependency versions"
+  desc "dependency diener is a tool for easily changing Polkadot SDK dependency versions"
   homepage "https://github.com/paritytech/diener"
   url "https://github.com/paritytech/diener/releases/download/v0.4.4/diener_macos_v0.4.4.tar.gz"
   sha256 "1caba305bcc460a528fbcf2f0a7dd519fb31ad21fffa9902d9497019809ff90b"
@@ -9,4 +9,3 @@ class Diener < Formula
     bin.install "diener"
   end
 end
-

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# diener - dependency diener is a tool for easily changing [Substrate](https://github.com/paritytech/substrate) or [Polkadot](https://github.com/paritytech/polkadot) dependency versions
+# diener - dependency diener is a tool for easily changing [Polkadot SDK](https://github.com/paritytech/polkadot-sdk) dependency versions
 
 [![](https://docs.rs/diener/badge.svg)](https://docs.rs/diener/) [![](https://img.shields.io/crates/v/diener.svg)](https://crates.io/crates/diener) [![](https://img.shields.io/crates/d/diener.png)](https://crates.io/crates/diener)
 
@@ -14,32 +14,23 @@ You can find the full documentation on [docs.rs](https://docs.rs/crate/diener).
 The `update` subcommand changes all `Cargo.toml` files in a given folder to use
 a specific branch/path/commit/tag.
 
-Change all Substrate dependencies in a folder to a different branch:
+Change all Polkadot SDK dependencies in a folder to a different branch:
 
 ```rust
-diener update --substrate --branch diener-branch
-```
-
-Or you want to change Polkadot and Substrate dependencies to the same branch:
-
-```rust
-diener update --branch diener-branch-2
+diener update --branch diener-branch
 ```
 
 Diener also supports `tag` and `rev` as arguments.
-
-If a dependency is belongs to Substrate or Polkadot is currently done by looking at the git url.
-It also only works for repos called `substrate` or `polkadot`.
 
 #### Patch
 
 The `patch` subcommand adds a patch section for each crate in a given cargo workspace
 to the workspace `Cargo.toml` file in some other cargo workspace.
 
-Patch all Substrate git dependencies to be build from a given path:
+Patch all git dependencies to be build from a given path:
 
 ```rust
-diener patch --crates-to-patch ../path/to/substrate/checkout --substrate
+diener patch --crates-to-patch ../path/to/polkadot-sdk/checkout
 ```
 
 This subcommand can be compared to `.cargo/config` without using a deprecated

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 /*!
 
-diener - dependency diener is a tool for easily changing [Substrate](https://github.com/paritytech/substrate), [Polkadot](https://github.com/paritytech/polkadot) and [Cumulus](https://github.com/paritytech/cumulus) dependency versions
+diener - dependency diener is a tool for easily changing [Polkadot SDK](https://github.com/paritytech/polkadot) dependency versions
 
 [![](https://docs.rs/diener/badge.svg)](https://docs.rs/diener/) [![](https://img.shields.io/crates/v/diener.svg)](https://crates.io/crates/diener) [![](https://img.shields.io/crates/d/diener.png)](https://crates.io/crates/diener)
 
@@ -14,32 +14,23 @@ diener - dependency diener is a tool for easily changing [Substrate](https://git
 The `update` subcommand changes all `Cargo.toml` files in a given folder to use
 a specific branch/path/commit/tag.
 
-Change all Substrate dependencies in a folder to a different branch:
+Change all Polkadot SDK dependencies in a folder to a different branch:
 
-```
-diener update --substrate --branch diener-branch
-```
-
-Or you want to change Polkadot, Substrate and Cumulus dependencies to the same branch:
-
-```
-diener update --branch diener-branch-2
+```rust
+diener update --branch diener-branch
 ```
 
 Diener also supports `tag` and `rev` as arguments.
-
-If a depdendency is belongs to Substrate, Polkadot or Cumulus is currently done by looking at the git url.
-It also only works for repos called `substrate`, `polkadot` or `cumulus`.
 
 ### Patch
 
 The `patch` subcommand adds a patch section for each crate in a given cargo workspace
 to the workspace `Cargo.toml` file in some other cargo workspace.
 
-Patch all Substrate git dependencies to be build from a given path:
+Patch all git dependencies to be build from a given path:
 
-```
-diener patch --crates-to-patch ../path/to/substrate/checkout --substrate
+```rust
+diener patch --crates-to-patch ../path/to/polkadot-sdk/checkout
 ```
 
 This subcommand can be compared to `.cargo/config` without using a deprecated
@@ -66,7 +57,7 @@ mod patch;
 mod update;
 mod workspacify;
 
-/// diener is a tool for easily finding and changing Substrate or Polkadot dependency versions.
+/// diener is a tool for easily finding and changing Polkadot SDK dependency versions.
 /// diener will not modified the cargo.lock file but update specific dependencies in the Cargo.toml files or the project.
 #[derive(Debug, StructOpt)]
 enum SubCommands {
@@ -93,7 +84,7 @@ enum SubCommands {
 /// Cli options of Diener
 #[derive(Debug, StructOpt)]
 #[structopt(
-    about = "Diener - dependency diener for replacing substrate, polkadot, cumulus or beefy versions in `Cargo.toml` files"
+    about = "Diener - dependency diener for replacing Polkadot SDK versions in `Cargo.toml` files"
 )]
 struct Options {
     #[structopt(subcommand)]

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -102,57 +102,19 @@ pub struct Patch {
     point_to_git_commit: Option<String>,
 
     /// The patch target that should be used.
+    /// The default is the official `polkadot-sdk` repository.
     ///
     /// The target is `[patch.TARGET]` in the final `Cargo.toml`.
     #[structopt(
         long,
-        conflicts_with_all = &[ "crates", "substrate", "cumulus", "polkadot", "beefy", "sdk" ]
+        conflicts_with_all = &[ "crates" ]
     )]
     target: Option<String>,
 
-    /// Use the official Polkadot-SDK monorepo as patch target.
-    #[structopt(
-    long,
-    conflicts_with_all = &[ "target", "substrate", "polkadot", "cumulus", "beefy", "crates" ]
-)]
-    sdk: bool,
-
-    /// Use the official Substrate repo as patch target.
+    /// Use `crates.io` as patch target instead.
     #[structopt(
         long,
-        short = "s",
-        conflicts_with_all = &[ "target", "polkadot", "cumulus", "crates", "beefy", "sdk" ]
-    )]
-    substrate: bool,
-
-    /// Use the official Polkadot repo as patch target.
-    #[structopt(
-        long,
-        short = "p",
-        conflicts_with_all = &[ "target", "substrate", "cumulus", "crates", "beefy", "sdk" ]
-    )]
-    polkadot: bool,
-
-    /// Use the official Cumulus repo as patch target.
-    #[structopt(
-        long,
-        short = "c",
-        conflicts_with_all = &[ "target", "substrate", "polkadot", "crates", "beefy", "sdk" ]
-    )]
-    cumulus: bool,
-
-    /// Use the official BEEFY repo as patch target.
-    #[structopt(
-        long,
-        short = "b",
-        conflicts_with_all = &[ "target", "substrate", "cumulus", "crates", "polkadot", "sdk" ]
-    )]
-    beefy: bool,
-
-    /// Use `crates.io` as patch target.
-    #[structopt(
-        long,
-        conflicts_with_all = &[ "target", "substrate", "polkadot", "cumulus", "beefy", "sdk" ]
+        conflicts_with_all = &[ "target" ]
     )]
     crates: bool,
 }
@@ -160,7 +122,7 @@ pub struct Patch {
 impl Patch {
     /// Run this subcommand.
     pub fn run(self) -> Result<()> {
-        let patch_target = self.patch_target()?;
+        let patch_target = self.patch_target();
         let path = self
             .path
             .map(|p| {
@@ -191,33 +153,13 @@ impl Patch {
         )
     }
 
-    fn patch_target(&self) -> Result<PatchTarget> {
+    fn patch_target(&self) -> PatchTarget {
         if let Some(ref custom) = self.target {
-            Ok(PatchTarget::Custom(custom.clone()))
-        } else if self.substrate {
-            Ok(PatchTarget::Git(
-                "https://github.com/paritytech/substrate".into(),
-            ))
-        } else if self.polkadot {
-            Ok(PatchTarget::Git(
-                "https://github.com/paritytech/polkadot".into(),
-            ))
-        } else if self.cumulus {
-            Ok(PatchTarget::Git(
-                "https://github.com/paritytech/cumulus".into(),
-            ))
-        } else if self.beefy {
-            Ok(PatchTarget::Git(
-                "https://github.com/paritytech/parity-bridges-gadget".into(),
-            ))
+            PatchTarget::Custom(custom.clone())
         } else if self.crates {
-            Ok(PatchTarget::Crates)
-        } else if self.sdk {
-            Ok(PatchTarget::Git(
-                "https://github.com/paritytech/polkadot-sdk".into(),
-            ))
+            PatchTarget::Crates
         } else {
-            bail!("You need to pass `--target`, `--sdk`, `--substrate`, `--polkadot`, `--cumulus`, `--beefy` or `--crates`!");
+            PatchTarget::Git("https://github.com/paritytech/polkadot-sdk".into())
         }
     }
 }

--- a/src/patch.rs
+++ b/src/patch.rs
@@ -106,15 +106,22 @@ pub struct Patch {
     /// The target is `[patch.TARGET]` in the final `Cargo.toml`.
     #[structopt(
         long,
-        conflicts_with_all = &[ "crates", "substrate", "cumulus", "polkadot", "beefy" ]
+        conflicts_with_all = &[ "crates", "substrate", "cumulus", "polkadot", "beefy", "sdk" ]
     )]
     target: Option<String>,
+
+    /// Use the official Polkadot-SDK monorepo as patch target.
+    #[structopt(
+    long,
+    conflicts_with_all = &[ "target", "substrate", "polkadot", "cumulus", "beefy", "crates" ]
+)]
+    sdk: bool,
 
     /// Use the official Substrate repo as patch target.
     #[structopt(
         long,
         short = "s",
-        conflicts_with_all = &[ "target", "polkadot", "cumulus", "crates", "beefy" ]
+        conflicts_with_all = &[ "target", "polkadot", "cumulus", "crates", "beefy", "sdk" ]
     )]
     substrate: bool,
 
@@ -122,7 +129,7 @@ pub struct Patch {
     #[structopt(
         long,
         short = "p",
-        conflicts_with_all = &[ "target", "substrate", "cumulus", "crates", "beefy" ]
+        conflicts_with_all = &[ "target", "substrate", "cumulus", "crates", "beefy", "sdk" ]
     )]
     polkadot: bool,
 
@@ -130,7 +137,7 @@ pub struct Patch {
     #[structopt(
         long,
         short = "c",
-        conflicts_with_all = &[ "target", "substrate", "polkadot", "crates", "beefy" ]
+        conflicts_with_all = &[ "target", "substrate", "polkadot", "crates", "beefy", "sdk" ]
     )]
     cumulus: bool,
 
@@ -138,14 +145,14 @@ pub struct Patch {
     #[structopt(
         long,
         short = "b",
-        conflicts_with_all = &[ "target", "substrate", "cumulus", "crates", "polkadot" ]
+        conflicts_with_all = &[ "target", "substrate", "cumulus", "crates", "polkadot", "sdk" ]
     )]
     beefy: bool,
 
     /// Use `crates.io` as patch target.
     #[structopt(
         long,
-        conflicts_with_all = &[ "target", "substrate", "polkadot", "cumulus", "beefy" ]
+        conflicts_with_all = &[ "target", "substrate", "polkadot", "cumulus", "beefy", "sdk" ]
     )]
     crates: bool,
 }
@@ -205,8 +212,12 @@ impl Patch {
             ))
         } else if self.crates {
             Ok(PatchTarget::Crates)
+        } else if self.sdk {
+            Ok(PatchTarget::Git(
+                "https://github.com/paritytech/polkadot-sdk".into(),
+            ))
         } else {
-            bail!("You need to pass `--target`, `--substrate`, `--polkadot`, `--cumulus`, `--beefy` or `--crates`!");
+            bail!("You need to pass `--target`, `--sdk`, `--substrate`, `--polkadot`, `--cumulus`, `--beefy` or `--crates`!");
         }
     }
 }

--- a/src/update.rs
+++ b/src/update.rs
@@ -13,6 +13,7 @@ enum Rewrite {
     Polkadot(Option<String>),
     Cumulus(Option<String>),
     Beefy(Option<String>),
+    Sdk(Option<String>),
 }
 
 /// The version the dependencies should be switched to.
@@ -49,6 +50,10 @@ pub struct Update {
     /// Alter polkadot, substrate + beefy dependencies
     #[structopt(long, short = "a")]
     all: bool,
+
+    /// Only alter Polkadot-SDK monorepo dependencies.
+    #[structopt(long, conflicts_with_all = &[ "substrate", "polkadot", "cumulus", "beefy", "all" ])]
+    sdk: bool,
 
     /// The `branch` that the dependencies should use.
     #[structopt(long, conflicts_with_all = &[ "rev", "tag" ])]
@@ -94,6 +99,8 @@ impl Update {
             Rewrite::Polkadot(self.git)
         } else if self.cumulus {
             Rewrite::Cumulus(self.git)
+        } else if self.sdk {
+            Rewrite::Sdk(self.git)
         } else {
             bail!("You must specify one of `--substrate`, `--polkadot`, `--cumulus`, `--beefy` or `--all`.");
         };

--- a/src/update.rs
+++ b/src/update.rs
@@ -5,17 +5,6 @@ use structopt::StructOpt;
 use toml_edit::{Document, InlineTable, Value};
 use walkdir::{DirEntry, WalkDir};
 
-/// Which dependencies should be rewritten?
-#[derive(Debug, Clone)]
-enum Rewrite {
-    All,
-    Substrate(Option<String>),
-    Polkadot(Option<String>),
-    Cumulus(Option<String>),
-    Beefy(Option<String>),
-    Sdk(Option<String>),
-}
-
 /// The version the dependencies should be switched to.
 #[derive(Debug, Clone)]
 enum Version {
@@ -30,30 +19,6 @@ pub struct Update {
     /// The path where Diener should search for `Cargo.toml` files.
     #[structopt(long)]
     path: Option<PathBuf>,
-
-    /// Only alter Substrate dependencies.
-    #[structopt(long, short = "s")]
-    substrate: bool,
-
-    /// Only alter Polkadot dependencies.
-    #[structopt(long, short = "p")]
-    polkadot: bool,
-
-    /// Only alter Cumulus dependencies.
-    #[structopt(long, short = "c")]
-    cumulus: bool,
-
-    /// Only alter BEEFY dependencies.
-    #[structopt(long, short = "b")]
-    beefy: bool,
-
-    /// Alter polkadot, substrate + beefy dependencies
-    #[structopt(long, short = "a")]
-    all: bool,
-
-    /// Only alter Polkadot-SDK monorepo dependencies.
-    #[structopt(long, conflicts_with_all = &[ "substrate", "polkadot", "cumulus", "beefy", "all" ])]
-    sdk: bool,
 
     /// The `branch` that the dependencies should use.
     #[structopt(long, conflicts_with_all = &[ "rev", "tag" ])]
@@ -73,8 +38,8 @@ pub struct Update {
 }
 
 impl Update {
-    /// Convert the options into the parts `Rewrite`, `Version`, `Option<PathBuf>`.
-    fn into_parts(self) -> Result<(Rewrite, Version, Option<PathBuf>)> {
+    /// Convert the options into the parts `Option<String>`, `Version`, `Option<PathBuf>`.
+    fn into_parts(self) -> Result<(Option<String>, Version, Option<PathBuf>)> {
         let version = if let Some(branch) = self.branch {
             Version::Branch(branch)
         } else if let Some(rev) = self.rev {
@@ -85,32 +50,12 @@ impl Update {
             bail!("You need to pass `--branch`, `--tag` or `--rev`");
         };
 
-        let rewrite = if self.all {
-            if self.git.is_some() {
-                bail!("You need to pass `--substrate`, `--polkadot`, `--cumulus` or `--beefy` for `--git`.");
-            } else {
-                Rewrite::All
-            }
-        } else if self.substrate {
-            Rewrite::Substrate(self.git)
-        } else if self.beefy {
-            Rewrite::Beefy(self.git)
-        } else if self.polkadot {
-            Rewrite::Polkadot(self.git)
-        } else if self.cumulus {
-            Rewrite::Cumulus(self.git)
-        } else if self.sdk {
-            Rewrite::Sdk(self.git)
-        } else {
-            bail!("You must specify one of `--substrate`, `--polkadot`, `--cumulus`, `--beefy` or `--all`.");
-        };
-
-        Ok((rewrite, version, self.path))
+        Ok((self.git, version, self.path))
     }
 
     /// Run this subcommand.
     pub fn run(self) -> Result<()> {
-        let (rewrite, version, path) = self.into_parts()?;
+        let (git, version, path) = self.into_parts()?;
 
         let path = path
             .map(Ok)
@@ -137,34 +82,24 @@ impl Update {
             .filter(|e| {
                 e.file_type().is_file() && e.file_name().to_string_lossy().ends_with("Cargo.toml")
             })
-            .try_for_each(|toml| handle_toml_file(toml.into_path(), &rewrite, &version))
+            .try_for_each(|toml| handle_toml_file(toml.into_path(), &git, &version))
     }
 }
 
 /// Handle a given dependency.
 ///
 /// This directly modifies the given `dep` in the requested way.
-fn handle_dependency(name: &str, dep: &mut InlineTable, rewrite: &Rewrite, version: &Version) {
-    let git = if let Some(git) = dep
+fn handle_dependency(name: &str, dep: &mut InlineTable, git: &Option<String>, version: &Version) {
+    if !dep
         .get("git")
         .and_then(|v| v.as_str())
         .and_then(|d| GitUrl::parse(d).ok())
+        .is_some_and(|git| git.name == "polkadot-sdk")
     {
-        git
-    } else {
         return;
-    };
+    }
 
-    let new_git = match rewrite {
-        Rewrite::All => &None,
-        Rewrite::Substrate(new_git) if git.name == "substrate" => new_git,
-        Rewrite::Polkadot(new_git) if git.name == "polkadot" => new_git,
-        Rewrite::Cumulus(new_git) if git.name == "cumulus" => new_git,
-        Rewrite::Beefy(new_git) if git.name == "grandpa-bridge-gadget" => new_git,
-        _ => return,
-    };
-
-    if let Some(new_git) = new_git {
+    if let Some(new_git) = git {
         *dep.get_or_insert("git", "") = Value::from(new_git.as_str()).decorated(" ", "");
     }
 
@@ -189,7 +124,7 @@ fn handle_dependency(name: &str, dep: &mut InlineTable, rewrite: &Rewrite, versi
 /// Handle a given `Cargo.toml`.
 ///
 /// This means scanning all dependencies and rewrite the requested onces.
-fn handle_toml_file(path: PathBuf, rewrite: &Rewrite, version: &Version) -> Result<()> {
+fn handle_toml_file(path: PathBuf, git: &Option<String>, version: &Version) -> Result<()> {
     log::info!("Processing: {}", path.display());
 
     let mut toml_doc = Document::from_str(&fs::read_to_string(&path)?)?;
@@ -210,7 +145,7 @@ fn handle_toml_file(path: PathBuf, rewrite: &Rewrite, version: &Version) -> Resu
                     let table = toml_doc[k][dn]
                         .as_inline_table_mut()
                         .expect("We filter by `is_inline_table`; qed");
-                    handle_dependency(dn, table, rewrite, version);
+                    handle_dependency(dn, table, git, version);
                 })
         });
 


### PR DESCRIPTION
This PR adds support for the Polkadot-SDK monorepo by introducing the flag `--sdk` in both patch and update commands. 